### PR TITLE
fix: set audio session type to playback

### DIFF
--- a/src/hooks/use-sound.ts
+++ b/src/hooks/use-sound.ts
@@ -25,6 +25,10 @@ export function useSound(
         preload: options.preload ?? false,
         src: src,
       });
+
+      if (window.navigator.audioSession) {
+        window.navigator.audioSession.type = 'playback';
+      }
     }
 
     return sound;


### PR DESCRIPTION
I hope you're open to PRs; no worries if not, feel free to decline :)

I noticed the Ambient Sounds player would not play audio on my iPhone with the system mute toggled on but would when unmuted. I read that howler.js does attempt to [autounlock](https://github.com/goldfire/howler.js?tab=readme-ov-file#mobilechrome-playback) this behavior, but it would seem it is unsuccessful in this scenario. My travels eventually led me to [this WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=237322) where this fix was shared.

I verified this works directly on my phone by running `npm start -- --host` to allow me to access astro from my phone.

If you'd like anything else included or changed, just let me know!